### PR TITLE
Add macOS support and startup parity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ defaults:
     shell: pwsh
 
 jobs:
-  build:
+  build-windows:
     runs-on: windows-latest
     permissions:
       contents: write
@@ -37,11 +37,57 @@ jobs:
     - name: upload artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: publish
+        name: publish-windows
+        path: |
+          ${{ github.workspace }}/publish/Meziantou.FileMover-win-x64.zip
+          ${{ github.workspace }}/publish/Meziantou.FileMover-win-arm64.zip
+
+  build-macos-arm64:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-dotnet@v5
+
+    - name: Test
+      run: dotnet test
+
+    - name: Build (macos-arm64)
+      run: dotnet publish Meziantou.FileMover/Meziantou.FileMover.csproj --configuration Release --runtime osx-arm64 --self-contained true --output ${{ github.workspace }}/publish/macos-arm64
+
+    - name: Create zip file
+      run: ditto -c -k --keepParent "${{ github.workspace }}/publish/macos-arm64" "${{ github.workspace }}/publish/Meziantou.FileMover-macos-arm64.zip"
+
+    - name: upload artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: publish-macos-arm64
+        path: ${{ github.workspace }}/publish/Meziantou.FileMover-macos-arm64.zip
+
+  release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs:
+    - build-windows
+    - build-macos-arm64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/download-artifact@v5
+      with:
+        name: publish-windows
+        path: ${{ github.workspace }}/publish
+    - uses: actions/download-artifact@v5
+      with:
+        name: publish-macos-arm64
         path: ${{ github.workspace }}/publish
 
-    - run: (gh release view $env:ReleaseName || gh release create $env:ReleaseName --generate-notes) && gh release upload $env:ReleaseName "${{ github.workspace }}/publish/Meziantou.FileMover-win-x64.zip" "${{ github.workspace }}/publish/Meziantou.FileMover-win-arm64.zip"
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    - run: |
+        gh release view "$ReleaseName" || gh release create "$ReleaseName" --generate-notes
+        gh release upload "$ReleaseName" \
+          "${{ github.workspace }}/publish/Meziantou.FileMover-win-x64.zip" \
+          "${{ github.workspace }}/publish/Meziantou.FileMover-win-arm64.zip" \
+          "${{ github.workspace }}/publish/Meziantou.FileMover-macos-arm64.zip"
+      shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
         ReleaseName: ${{ github.ref_name }}

--- a/Meziantou.FileMover.Tests/Meziantou.FileMover.Tests.csproj
+++ b/Meziantou.FileMover.Tests/Meziantou.FileMover.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFramework>net$(NETCoreAppMaximumVersion)-windows</TargetFramework>
+    <TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Meziantou.FileMover.Tests/UnitTest1.cs
+++ b/Meziantou.FileMover.Tests/UnitTest1.cs
@@ -51,11 +51,38 @@ public class UnitTest1
         {
         }
 
-        var files = Directory.GetFiles(dir.FullPath, "*", SearchOption.AllDirectories).Select(FullPath.FromPath).Select(path => path.MakePathRelativeTo(dir.FullPath)).Order(StringComparer.Ordinal);
+        var files = Directory.GetFiles(dir.FullPath, "*", SearchOption.AllDirectories)
+            .Select(FullPath.FromPath)
+            .Select(path => path.MakePathRelativeTo(dir.FullPath).ToString().Replace('\\', '/'))
+            .Order(StringComparer.Ordinal);
         InlineSnapshot.Validate(files, """
             - config.json
-            - dst\test.test
+            - dst/test.test
             - other
+            """);
+    }
+
+    [Fact]
+    public void CreateMacOSLaunchAgentPlistContent_EscapesProgramPath()
+    {
+        var content = StartupRegistration.CreateMacOSLaunchAgentPlistContent("/Applications/FileMover & Co/FileMover");
+        InlineSnapshot.Validate(content.ReplaceLineEndings("\n"), """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>Label</key>
+              <string>com.meziantou.filemover</string>
+              <key>ProgramArguments</key>
+              <array>
+                <string>/Applications/FileMover &amp; Co/FileMover</string>
+              </array>
+              <key>RunAtLoad</key>
+              <true/>
+              <key>ProcessType</key>
+              <string>Background</string>
+            </dict>
+            </plist>
             """);
     }
 }

--- a/Meziantou.FileMover/AssemblyInfo.cs
+++ b/Meziantou.FileMover/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Meziantou.FileMover.Tests")]

--- a/Meziantou.FileMover/Meziantou.FileMover.csproj
+++ b/Meziantou.FileMover/Meziantou.FileMover.csproj
@@ -1,13 +1,17 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType Condition="$(Configuration) == 'Release'">WinExe</OutputType>
-    <OutputType Condition="$(Configuration) == 'Debug'">Exe</OutputType>
-    <TargetFramework>net$(NETCoreAppMaximumVersion)-windows</TargetFramework>
-    
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>
+
     <PublishAot>true</PublishAot>
     <StripSymbols>true</StripSymbols>
     <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType Condition="'$(Configuration)' == 'Release' and '$(RuntimeIdentifier)' == 'win-x64'">WinExe</OutputType>
+    <OutputType Condition="'$(Configuration)' == 'Release' and '$(RuntimeIdentifier)' == 'win-arm64'">WinExe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Meziantou.FileMover/Program.cs
+++ b/Meziantou.FileMover/Program.cs
@@ -4,14 +4,13 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.Win32;
 
 namespace Meziantou.FileMover;
 public static class Program
 {
     public static async Task Main(string[] args)
     {
-        RegisterAsStartup();
+        StartupRegistration.RegisterAsStartup();
 
         using var cts = new CancellationTokenSource();
         Console.CancelKeyPress += (sender, e) =>
@@ -21,15 +20,6 @@ public static class Program
         };
 
         await MainCore(args, cts.Token);
-
-        static void RegisterAsStartup()
-        {
-            if (Environment.ProcessPath is { } processPath)
-            {
-                using var key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", writable: true);
-                key.SetValue("Meziantou_FileMover", processPath);
-            }
-        }
     }
 
     public static async Task MainCore(string[] args, CancellationToken cancellationToken)

--- a/Meziantou.FileMover/StartupRegistration.cs
+++ b/Meziantou.FileMover/StartupRegistration.cs
@@ -1,0 +1,83 @@
+using System.Security;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace Meziantou.FileMover;
+
+internal static class StartupRegistration
+{
+    private const string WindowsRunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
+    private const string WindowsRunValueName = "Meziantou_FileMover";
+    private const string MacOSLaunchAgentLabel = "com.meziantou.filemover";
+
+    internal static void RegisterAsStartup()
+    {
+        if (Environment.ProcessPath is not { } processPath)
+            return;
+
+        if (OperatingSystem.IsWindows())
+        {
+            RegisterWindows(processPath);
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            RegisterMacOS(processPath);
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void RegisterWindows(string processPath)
+    {
+        using var key = Registry.CurrentUser.CreateSubKey(WindowsRunKeyPath, writable: true);
+        key?.SetValue(WindowsRunValueName, processPath);
+    }
+
+    [SupportedOSPlatform("macos")]
+    private static void RegisterMacOS(string processPath)
+    {
+        var userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(userProfilePath))
+            return;
+
+        var launchAgentPath = GetMacOSLaunchAgentPath(userProfilePath);
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(launchAgentPath)!);
+
+        var content = CreateMacOSLaunchAgentPlistContent(processPath);
+        if (File.Exists(launchAgentPath))
+        {
+            var currentContent = File.ReadAllText(launchAgentPath);
+            if (string.Equals(currentContent, content, StringComparison.Ordinal))
+                return;
+        }
+
+        File.WriteAllText(launchAgentPath, content);
+    }
+
+    internal static string GetMacOSLaunchAgentPath(string userProfilePath)
+    {
+        return Path.Combine(userProfilePath, "Library", "LaunchAgents", $"{MacOSLaunchAgentLabel}.plist");
+    }
+
+    internal static string CreateMacOSLaunchAgentPlistContent(string processPath)
+    {
+        var escapedProcessPath = SecurityElement.Escape(processPath) ?? processPath;
+        return $$"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>Label</key>
+              <string>{{MacOSLaunchAgentLabel}}</string>
+              <key>ProgramArguments</key>
+              <array>
+                <string>{{escapedProcessPath}}</string>
+              </array>
+              <key>RunAtLoad</key>
+              <true/>
+              <key>ProcessType</key>
+              <string>Background</string>
+            </dict>
+            </plist>
+            """;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # Meziantou.FileMover
+
+Watches directories and automatically moves or deletes files based on rules from `Meziantou.FileMover.json`.
+
+## Configuration
+
+The configuration file contains a `Rules` array:
+
+```json
+{
+  "Rules": [
+    {
+      "Action": "Move",
+      "Source": "%USERPROFILE%\\Downloads",
+      "Destination": "Z:\\zips",
+      "Pattern": "*.zip",
+      "Delay": "00:00:10"
+    },
+    {
+      "Action": "Delete",
+      "Source": "%USERPROFILE%\\Downloads",
+      "Pattern": "Sample"
+    }
+  ]
+}
+```
+
+For macOS, use POSIX paths in `Source` and `Destination` (for example `/Users/your-user/Downloads`).
+
+## Startup registration
+
+The application registers itself at user login on startup:
+
+- **Windows:** `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`
+- **macOS:** `~/Library/LaunchAgents/com.meziantou.filemover.plist`
+
+Windows release builds use `WinExe` when published for Windows runtimes, so no console window is shown at startup.  
+On macOS, the LaunchAgent is configured as a background process (`ProcessType=Background`) for equivalent non-interactive startup behavior.
+
+## macOS notes
+
+- Keep the binary in a stable path because the LaunchAgent points to the executable location.
+- Startup is user-scoped (LaunchAgent), not system-wide (LaunchDaemon).
+- If you distribute binaries, make sure signing/notarization expectations are handled for Gatekeeper.


### PR DESCRIPTION
## Why
The app was Windows-only and relied on Windows startup registration. We need equivalent file-moving behavior on macOS, including startup at login, while keeping the existing Windows behavior.

## What changed
- Retargeted app and tests from Windows-only TFM to cross-platform `net$(NETCoreAppMaximumVersion)`.
- Extracted startup registration into OS-specific logic:
  - Windows still uses `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run`.
  - macOS now writes a LaunchAgent plist at `~/Library/LaunchAgents/com.meziantou.filemover.plist`.
- Added macOS LaunchAgent `ProcessType=Background` for non-interactive startup behavior.
- Restored Windows no-console behavior for release publishes by using `WinExe` when RID is `win-x64` or `win-arm64`.
- Updated publish workflow:
  - keep Windows publish artifacts
  - add self-contained `osx-arm64` publish + zip artifact
  - unified release job uploads all platform zips
- Updated tests for cross-platform path separators and LaunchAgent plist snapshot.
- Updated README with macOS configuration and startup notes.

## Notes for reviewers
- There is no direct `WinExe` equivalent on macOS; parity is implemented through LaunchAgent background startup (`ProcessType=Background`).
- Existing move/delete logic remains unchanged; changes are focused on platform compatibility and startup/publish behavior.