### PR TITLE
Upgrade tests to xunit.v3

### DIFF
--- a/Meziantou.FileMover.Tests/Meziantou.FileMover.Tests.csproj
+++ b/Meziantou.FileMover.Tests/Meziantou.FileMover.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="5.0.2" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="2.0.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
This updates the test project to xUnit v3 so the test stack stays aligned with the current package line.

The test project now references `xunit.v3` (`3.2.2`) instead of `xunit` (`2.9.3`). The existing `xunit.runner.visualstudio` reference (`3.1.5`) is already v3-compatible and remains unchanged.

## Notes
`dotnet` is not available in this execution environment, so tests could not be run here.