### PR TITLE
Update Meziantou.NET.Sdk to 1.0.148

### DIFF
--- a/Meziantou.FileMover.Tests/Meziantou.FileMover.Tests.csproj
+++ b/Meziantou.FileMover.Tests/Meziantou.FileMover.Tests.csproj
@@ -7,8 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="6.0.1" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="3.0.1" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -2,8 +2,11 @@
   "sdk": {
     "version": "10.0.302"
   },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.130",
-    "Meziantou.NET.Sdk.Test": "1.0.130"
+    "Meziantou.NET.Sdk": "1.0.148",
+    "Meziantou.NET.Sdk.Test": "1.0.148"
   }
 }


### PR DESCRIPTION
Update `Meziantou.NET.Sdk` to 1.0.148 in `global.json`.

- Opt in to Microsoft Testing Platform via the `test.runner` setting in `global.json`
- Remove the `xunit.v3` / `xunit.runner.visualstudio` package references, now added by `Meziantou.NET.Sdk.Test`
