### PR TITLE
Update Meziantou.NET.Sdk to 1.0.149

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.148",
-    "Meziantou.NET.Sdk.Test": "1.0.148"
+    "Meziantou.NET.Sdk": "1.0.149",
+    "Meziantou.NET.Sdk.Test": "1.0.149"
   }
 }


### PR DESCRIPTION
Update `Meziantou.NET.Sdk` from 1.0.148 to 1.0.149.

1.0.149 uses [`Meziantou.Framework.Assertions`](https://www.nuget.org/packages/Meziantou.Framework.Assertions) as the default assertion library, so `Assert` now refers to `Meziantou.Framework.Assertions.Assert` in the test projects.

Files changed:
- global.json